### PR TITLE
Send dataType as text

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -60,7 +60,7 @@ function addTracksToPlaylist(username, playlist, tracks, callback) {
 	$.ajax(url, {
 		method: 'POST',
 		data: JSON.stringify(tracks),
-		dataType: 'json',
+		dataType: 'text',
 		headers: {
 			'Authorization': 'Bearer ' + g_access_token,
 			'Content-Type': 'application/json'


### PR DESCRIPTION
If the dataType is set to JSON, as the response is empty JSON.parse
fails and the error callback gets called
See http://stackoverflow.com/questions/2233553/data-inserted-successful-but-jquery-still-returning-error
