### PR TITLE
Changed JQuery source to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<script type="text/javascript" src="http://code.jquery.com/jquery-1.11.1.js"></script>
+<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.1.js"></script>
 <script type="text/javascript" src="fuzzyset.js"></script>
 <script type="text/javascript" src="wordcache.js"></script>
 <script type="text/javascript" src="app.js"></script>


### PR DESCRIPTION
Changed the source of the jQuery CDN to https so that it would not give the error:
```Mixed Content: The page at 'https://lab.possan.se/playlistcreator-example/' was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/jquery-1.11.1.js'. This request has been blocked; the content must be served over HTTPS.```